### PR TITLE
Simplify metrics card titles

### DIFF
--- a/app/metrics/page.tsx
+++ b/app/metrics/page.tsx
@@ -239,9 +239,7 @@ function MetricsPageContent() {
             <TabsContent value="steps" className="mt-4 space-y-4">
               <Card>
                 <CardHeader>
-                  <CardTitle className="text-base">
-                    Steps for {selectedStepsDate === today ? "Today" : selectedStepsDate}
-                  </CardTitle>
+                  <CardTitle className="text-base">Steps</CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="space-y-2">
@@ -317,9 +315,7 @@ function MetricsPageContent() {
             <TabsContent value="weight" className="mt-4 space-y-4">
               <Card>
                 <CardHeader>
-                  <CardTitle className="text-base">
-                    Weight for {selectedWeightDate === today ? "Today" : selectedWeightDate}
-                  </CardTitle>
+                  <CardTitle className="text-base">Weight</CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="space-y-2">


### PR DESCRIPTION
Remove date-specific text from card titles.
Changed "Steps for Today/date" to just "Steps"
Changed "Weight for Today/date" to just "Weight"

The date picker already shows which date is being edited, making the dynamic title text redundant.