### PR TITLE
Fix Safari iOS voice transcription by prioritizing audio/mp4 codec

### DIFF
--- a/components/voice-meal-logger.tsx
+++ b/components/voice-meal-logger.tsx
@@ -19,6 +19,7 @@ export function VoiceMealLogger({ onMealSaved }: VoiceMealLoggerProps) {
     audioBlob,
     duration,
     error: recorderError,
+    mimeType,
     startRecording,
     stopRecording,
     reset: resetRecorder,
@@ -30,6 +31,17 @@ export function VoiceMealLogger({ onMealSaved }: VoiceMealLoggerProps) {
   const [currentTranscript, setCurrentTranscript] = useState("");
   const processingRef = useRef(false);
 
+  // Helper function to get file extension from MIME type
+  const getFileExtension = (mimeType: string | null): string => {
+    if (!mimeType) return "webm";
+    if (mimeType.includes("mp4")) return "mp4";
+    if (mimeType.includes("webm")) return "webm";
+    if (mimeType.includes("ogg")) return "ogg";
+    if (mimeType.includes("wav")) return "wav";
+    if (mimeType.includes("mpeg")) return "mp3";
+    return "webm"; // default fallback
+  };
+
   // Handle recording completion
   const handleRecordingComplete = useCallback(async (blob: Blob) => {
     if (processingRef.current) return;
@@ -38,7 +50,8 @@ export function VoiceMealLogger({ onMealSaved }: VoiceMealLoggerProps) {
 
     try {
       const formData = new FormData();
-      formData.append("audio", blob, "recording.webm");
+      const extension = getFileExtension(mimeType);
+      formData.append("audio", blob, `recording.${extension}`);
 
       const response = await fetch("/api/transcribe", {
         method: "POST",
@@ -61,7 +74,7 @@ export function VoiceMealLogger({ onMealSaved }: VoiceMealLoggerProps) {
     } finally {
       processingRef.current = false;
     }
-  }, [resetRecorder]);
+  }, [mimeType, resetRecorder]);
 
   // Effect to handle audio blob changes
   useEffect(() => {

--- a/components/voice-workout-logger.tsx
+++ b/components/voice-workout-logger.tsx
@@ -20,6 +20,7 @@ export function VoiceWorkoutLogger({ sessionId, onSetSaved }: VoiceWorkoutLogger
     audioBlob,
     duration,
     error: recorderError,
+    mimeType,
     startRecording,
     stopRecording,
     reset: resetRecorder,
@@ -31,6 +32,17 @@ export function VoiceWorkoutLogger({ sessionId, onSetSaved }: VoiceWorkoutLogger
   const [currentTranscript, setCurrentTranscript] = useState("");
   const processingRef = useRef(false);
 
+  // Helper function to get file extension from MIME type
+  const getFileExtension = (mimeType: string | null): string => {
+    if (!mimeType) return "webm";
+    if (mimeType.includes("mp4")) return "mp4";
+    if (mimeType.includes("webm")) return "webm";
+    if (mimeType.includes("ogg")) return "ogg";
+    if (mimeType.includes("wav")) return "wav";
+    if (mimeType.includes("mpeg")) return "mp3";
+    return "webm"; // default fallback
+  };
+
   // Handle recording completion
   const handleRecordingComplete = useCallback(async (blob: Blob) => {
     if (processingRef.current) return;
@@ -39,7 +51,8 @@ export function VoiceWorkoutLogger({ sessionId, onSetSaved }: VoiceWorkoutLogger
 
     try {
       const formData = new FormData();
-      formData.append("audio", blob, "recording.webm");
+      const extension = getFileExtension(mimeType);
+      formData.append("audio", blob, `recording.${extension}`);
 
       const response = await fetch("/api/transcribe", {
         method: "POST",
@@ -62,7 +75,7 @@ export function VoiceWorkoutLogger({ sessionId, onSetSaved }: VoiceWorkoutLogger
     } finally {
       processingRef.current = false;
     }
-  }, [resetRecorder]);
+  }, [mimeType, resetRecorder]);
 
   // Effect to handle audio blob changes
   useEffect(() => {


### PR DESCRIPTION
Safari on iOS has limited MediaRecorder codec support and does not support
audio/webm or opus codec. This commit fixes voice transcription failures on
Safari iOS by:

1. Prioritizing audio/mp4 format (Safari's native format) in codec detection
2. Tracking the selected MIME type and returning it from useVoiceRecorder hook
3. Using correct file extension when uploading audio to transcription API
4. Adding proper fallback strategy for unsupported formats

Changes:
- hooks/use-voice-recorder.ts: Reorder codec detection to try Safari-compatible
  formats first, add mimeType to return type
- components/voice-meal-logger.tsx: Use dynamic file extension based on MIME type
- components/voice-workout-logger.tsx: Use dynamic file extension based on MIME type