### PR TITLE
Switch transcription model to gpt-4o-mini-transcribe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ This is a Next.js 16 health tracking app with voice-first input for meals and wo
 - **Frontend**: Next.js App Router, React 19, Tailwind CSS 4, Radix UI components
 - **Backend**: Next.js API routes, Prisma ORM with Neon (serverless PostgreSQL)
 - **Auth**: Clerk (`@clerk/nextjs`)
-- **AI Services**: OpenAI for audio transcription (`gpt-4o-transcribe`), Google Gemini for interpretation (`gemini-3-flash-preview`)
+- **AI Services**: OpenAI for audio transcription (`gpt-4o-mini-transcribe`), Google Gemini for interpretation (`gemini-3-flash-preview`)
 
 ### Data Flow
 1. User records voice input via `MicRecordButton` component

--- a/app/api/transcribe/route.ts
+++ b/app/api/transcribe/route.ts
@@ -25,10 +25,10 @@ export async function POST(request: NextRequest) {
       return errorResponse("Audio file too large. Maximum size is 25MB.");
     }
 
-    // Transcribe using gpt-4o-transcribe
+    // Transcribe using gpt-4o-mini-transcribe
     const transcription = await openai.audio.transcriptions.create({
       file: audioFile,
-      model: "gpt-4o-transcribe",
+      model: "gpt-4o-mini-transcribe",
       response_format: "text",
     });
 


### PR DESCRIPTION
Updated OpenAI audio transcription to use gpt-4o-mini-transcribe instead of gpt-4o-transcribe for more cost-effective transcription.