### PR TITLE
Weekly trends: show calorie over/under bars and workout day check indicators

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -211,7 +211,10 @@ export default function DashboardPage() {
           {isLoading ? (
             <Skeleton className="h-[340px] w-full rounded-2xl" />
           ) : data ? (
-            <WeeklyTrendsCard data={data.weeklyTrends} />
+            <WeeklyTrendsCard
+              data={data.weeklyTrends}
+              calorieGoal={data.today.calories.goal}
+            />
           ) : null}
         </div>
       </main>


### PR DESCRIPTION
### Motivation

- Improve clarity of the weekly trends UI by showing calories relative to the user's goal instead of a raw line chart and by replacing the workouts line with a simple day-by-day indicator.
- Present calories as over/under target (so users can quickly see days they were above/below their goal) and make workout days visually obvious with clean checks.

### Description

- Replaced the calories `LineChart` with a `BarChart` that computes `calorieDelta` (calories minus `calorieGoal`) and renders bars above/below a `ReferenceLine` at `y=0`.
- Added `calorieGoal` prop to `WeeklyTrendsCard` and passed `data.today.calories.goal` from the dashboard page as `calorieGoal`.
- Color-coded bars via `Cell` so positive deltas use `var(--color-destructive)` and negatives use `var(--color-primary)`, and adjusted Y axis domain and tooltip formatting to show `+/-` kcal.
- Replaced the workouts `LineChart` with a compact 7-column grid showing a circular check (`Check` from `lucide-react`) for days with workouts and a muted placeholder for rest days, plus a short explanatory label under the calories chart.

### Testing

- Started the dev server with `npm run dev` and launched a Playwright script to open `/dashboard` and capture a screenshot, but the dashboard returned a `500` due to a missing Clerk publishable key so the UI could not be fully validated.
- The changes compile locally enough to be previewed, but end-to-end UI validation was blocked by the runtime configuration error (Clerk key missing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f1403978832ab4c2a390ff16449f)