### PR TITLE
Exclude today from weekly trends chart

### DIFF
--- a/components/weekly-trends-card.tsx
+++ b/components/weekly-trends-card.tsx
@@ -33,7 +33,10 @@ export function WeeklyTrendsCard({ data, calorieGoal }: WeeklyTrendsCardProps) {
     return date.toLocaleDateString("en-US", { weekday: "short" });
   };
 
-  const chartData = data.map((d) => ({
+  const todayKey = new Date().toLocaleDateString("en-CA");
+  const filteredData = data.filter((d) => d.date !== todayKey);
+
+  const chartData = filteredData.map((d) => ({
     ...d,
     displayDate: formatDate(d.date),
     calorieDelta: d.calories - calorieGoal,


### PR DESCRIPTION
### Motivation

- Today's in-progress calorie totals can be misleading and distort the chart's y-axis, so the weekly view should only show completed days.
- The change ensures the weekly trends chart focuses on meaningful completed-day data rather than partial values for the current day.

### Description

- Compute `todayKey` using `new Date().toLocaleDateString("en-CA")` and filter out any entry where `d.date === todayKey` before building `chartData`.
- Replace the previous `data.map(...)` with `filteredData.map(...)` so the chart no longer includes today's in-progress values.
- No other UI or data transformations were changed; existing domain/tick calculations and rendering remain the same.

### Testing

- Launched the dev server with `npm run dev` and it started, but runtime warnings about Google Fonts occurred and a missing Clerk `publishableKey` caused a `500` on page load. 
- Ran a Playwright script to capture a screenshot of the weekly trends view and the artifact was produced despite the environment key error.
- No automated unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968f446cc44832abd1d953fe8af0b42)