### PR TITLE
Adjust chat UI contrast and layout

### DIFF
--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -28,7 +28,7 @@ export function ChatComposer({ value, onChange, onSend, disabled }: ChatComposer
         onChange={(event) => onChange(event.target.value)}
         onKeyDown={handleKeyDown}
         placeholder="Ask about calories, workouts, or trends..."
-        className="min-h-[72px] resize-none border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
+        className="min-h-[72px] resize-none border-0 bg-transparent px-1 py-1 text-sm leading-relaxed shadow-none focus-visible:ring-0"
       />
       <div className="mt-2 flex items-center justify-between">
         <span className="text-[11px] text-muted-foreground">Read‑only coach</span>

--- a/components/conversation-input.tsx
+++ b/components/conversation-input.tsx
@@ -678,28 +678,31 @@ export function ConversationInput({
           )}
         >
           <div className="overflow-hidden">
-            <div className="flex items-center gap-3 p-2 pl-4">
+            <div className="flex items-center gap-2 p-2 pl-4">
               {/* Expand trigger / hint text */}
               <button
                 onClick={() => setIsExpanded(true)}
-                className="flex-1 flex items-center gap-3 text-left group"
+                className="flex-1 min-w-0 flex items-center gap-2 text-left group"
               >
-                <Sparkles className="w-4 h-4 text-primary-strong/60 group-hover:text-primary-strong transition-colors" />
+                <Sparkles className="w-4 h-4 text-primary-strong/60 group-hover:text-primary-strong transition-colors shrink-0" />
                 <span className="text-sm text-muted-foreground group-hover:text-foreground/80 transition-colors truncate">
-                  Log a meal, workout, or ask a question...
+                  <span className="sm:hidden">Log or ask…</span>
+                  <span className="hidden sm:inline">
+                    Log a meal, workout, or ask a question...
+                  </span>
                 </span>
               </button>
 
               <button
                 type="button"
                 onClick={() => handleOpenChat()}
-                className="flex items-center justify-center w-10 h-10 rounded-full border border-border/60 bg-muted/60 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground dark:bg-white/[0.06] dark:hover:bg-white/[0.12]"
+                className="hidden sm:flex items-center justify-center w-10 h-10 rounded-full border border-border/60 bg-muted/60 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground dark:bg-white/[0.06] dark:hover:bg-white/[0.12]"
               >
                 <Sparkles className="w-4 h-4" />
               </button>
 
               {/* Mic Button - Hero Element */}
-              <div className="relative">
+              <div className="relative shrink-0">
                 {/* Pulse ring animation */}
                 {!isRecording && !isBusy && (
                   <div className="absolute inset-0 rounded-full bg-primary/20 animate-pulse-ring" />


### PR DESCRIPTION
## Summary
- refresh chat and dashboard assets to improve button/icon contrast and better reflect the coach/mic styling adjustments
- tighten up responsive layouts for the command center, bottom navigation, and chat tray so elements no longer break on small screens
- tweak assistant prompts, metrics, and validation helpers to stay in sync with the refreshed UI flow

## Testing
- Not run (not requested)